### PR TITLE
#165625890 Admin view all loan Endpoint functionality

### DIFF
--- a/server/api/v1/controllers/loanController.js
+++ b/server/api/v1/controllers/loanController.js
@@ -150,6 +150,7 @@ const loanRepayment = (req, res) => {
   });
 };
 
+// eslint-disable-next-line consistent-return
 const getRepayment = (req, res) => {
   const loanId = Number(req.params.loanId);
   const existingLoan = loans.find(loan => loan.loanId === loanId);
@@ -159,18 +160,19 @@ const getRepayment = (req, res) => {
       const repaymentTransaction = loanRepayments
         .filter(repayment => repayment.loanId === loanId);
       if (repaymentTransaction) {
-        res.status(200).json({
+        if (repaymentTransaction.length === 0) {
+          return res.status(404).json({
+            status: 404,
+            data: 'Loan repayment transaction NOT found for this loan.',
+          });
+        }
+        return res.status(200).json({
           status: 200,
           data: repaymentTransaction,
         });
-      } else if (repaymentTransaction.length === 0) {
-        res.status(404).json({
-          status: 404,
-          data: 'Loan repayment transaction NOT found for this loan.',
-        });
       }
     } else {
-      res.status(400).json({
+      return res.status(400).json({
         status: 400,
         error: 'You can\'t view this loan repayment transaction',
       });
@@ -182,9 +184,31 @@ const getRepayment = (req, res) => {
     });
   }
 };
+
+const getAllLoan = (req, res) => {
+  if (req.authData.isAdmin) {
+    if (loans.length === 0) {
+      return res.status(200).json({
+        status: 404,
+        data: loans,
+      });
+    }
+    return res.status(200).json({
+      status: 200,
+      data: loans,
+    });
+  }
+  return res.status(403).json({
+    status: 403,
+    error: 'You\'re forbidden to perform this action.',
+  });
+};
+
+
 export default {
   applyForLoan,
   adminApproveRejectLoan,
   loanRepayment,
   getRepayment,
+  getAllLoan,
 };

--- a/server/api/v1/routes/loanRoute.js
+++ b/server/api/v1/routes/loanRoute.js
@@ -10,5 +10,6 @@ loanRouter.post('/', jwt.validateToken, loanValidator.valiidateLoan, loanControl
 loanRouter.patch('/:loanId', jwt.validateToken, loanValidator.validateLoanStatus, loanController.adminApproveRejectLoan);
 loanRouter.post('/:loanId/repayment', jwt.validateToken, loanValidator.valiidateLoanRepayment, loanController.loanRepayment);
 loanRouter.get('/:loanId/repayment', jwt.validateToken, loanValidator.validateLoanId, loanController.getRepayment);
+loanRouter.get('/', jwt.validateToken, loanController.getAllLoan);
 
 export default loanRouter;


### PR DESCRIPTION
#### What does this PR do?
Add admin view all loan API endpoint functionality

#### Description of Task to be completed?
Have this endpoint working:
GET: localhost:7000/api/v1/loans/

#### How should this be manually tested?
After cloning the repo, cd into the repo ```cd quickcredit```, install dependency by running ```npm install```

- Testing with Mocha: ```run npm test```
- Testing with Postman: test every endpoint with this header: ```key: Content-Type value: application/json```
**Login with seeded admin credentials:** ```{ "email": "admin@quickcredit.com", "password": "admin password in .env file created" }``` **POST** request to ```localhost:7000/api/v1/users/auth/login```
**Admin views all loan applications by making GET request:**
Ensure authentication and authorization are provided, add **token** to header. Get the token from login endpoint: **SET** ```Bearer <token> **GET** request to ```localhost:7000/api/v1/loans```

#### Any background context you want to provide?
**SET** Admin password in ```.env``` by setting: ```ADMIN_PASS=admin_password```

#### What are the relevant pivotal tracker stories?
#165625890 

#### Screenshots (if appropriate)
Nil

#### Questions:
Nil