### PR TITLE
#165626029 Add admin view current and repaid loans endpoint

### DIFF
--- a/server/api/v1/controllers/loanController.js
+++ b/server/api/v1/controllers/loanController.js
@@ -184,6 +184,22 @@ const getRepayment = (req, res) => {
 
 const getAllLoan = (req, res) => {
   if (req.authData.isAdmin) {
+    const { status } = req.query;
+    const { repaid } = req.query;
+    if (typeof status !== 'undefined' && typeof repaid !== 'undefined') {
+      if (status !== 'approved') {
+        return res.status(400).json({ status: 400, error: 'status can only have the value: \'approved\'' });
+      }
+      if (repaid.toString() !== 'true' && repaid.toString() !== 'false') {
+        return res.status(400).json({ status: 400, error: 'repaid can only have the value: \'true\' or \'false\'' });
+      }
+      const currentLoans = loans.filter(existingLoan => ((existingLoan.status === status)
+      && ((existingLoan.repaid).toString() === repaid.toString())));
+      return res.status(200).json({
+        status: 200,
+        data: currentLoans,
+      });
+    }
     if (loans.length === 0) {
       return res.status(200).json({
         status: 404,
@@ -221,7 +237,6 @@ const getALoan = (req, res) => {
     error: 'You\'re forbidden to perform this action.',
   });
 };
-
 
 export default {
   applyForLoan,

--- a/server/api/v1/db/loans.js
+++ b/server/api/v1/db/loans.js
@@ -44,6 +44,21 @@ const loans = [
     purpose: 'Education',
     createdOn: new Date(),
   },
+  {
+    loanId: 34526719,
+    firstName: 'taiwo',
+    lastName: 'charles',
+    user: 'taewole@gmail.com',
+    tenor: 3,
+    amount: 90000,
+    status: 'approved',
+    repaid: true,
+    balance: 94500,
+    interest: 4500,
+    paymentInstallment: 31500.00,
+    purpose: 'Travel',
+    createdOn: new Date(),
+  },
 ];
 
 export default loans;

--- a/server/test/tests.js
+++ b/server/test/tests.js
@@ -1091,6 +1091,50 @@ describe('User View Repayment History Test', () => {
           done();
         });
     });
+    it('admin should be able to view all current loan application', (done) => {
+      chai.request(server)
+        .get('/api/v1/loans/?status=approved&repaid=false')
+        .set('authorization', `Bearer ${adminToken}`)
+        .end((err, res) => {
+          res.body.should.have.status(200);
+          res.body.should.be.a('object');
+          res.body.data.should.be.a('array');
+          done();
+        });
+    });
+    it('admin should be able to view all paid loan application', (done) => {
+      chai.request(server)
+        .get('/api/v1/loans/?status=approved&repaid=true')
+        .set('authorization', `Bearer ${adminToken}`)
+        .end((err, res) => {
+          res.body.should.have.status(200);
+          res.body.should.be.a('object');
+          res.body.data.should.be.a('array');
+          done();
+        });
+    });
+    it('should fail if query status is not approved', (done) => {
+      chai.request(server)
+        .get('/api/v1/loans/?status=approve&repaid=true')
+        .set('authorization', `Bearer ${adminToken}`)
+        .end((err, res) => {
+          res.body.should.have.status(400);
+          res.body.should.be.a('object');
+          res.body.error.should.be.a('string').eql('status can only have the value: \'approved\'');
+          done();
+        });
+    });
+    it('should fail if query repaid is not correct', (done) => {
+      chai.request(server)
+        .get('/api/v1/loans/?status=approved&repaid=truty')
+        .set('authorization', `Bearer ${adminToken}`)
+        .end((err, res) => {
+          res.body.should.have.status(400);
+          res.body.should.be.a('object');
+          res.body.error.should.be.a('string').eql('repaid can only have the value: \'true\' or \'false\'');
+          done();
+        });
+    });
     it('should return empty array if admin token is VALID and no loan exists yet', (done) => {
       loans.splice(0, loans.length);
       chai.request(server)


### PR DESCRIPTION
#### What does this PR do?
Add admin view current and repaid loans endpoint

#### Description of Task to be completed?
Have these endpoints working:
GET: localhost:7000/api/v1/loans/?status=approved&repaid=false
GET: localhost:7000/api/v1/loans/?status=approved&repaid=true

#### How should this be manually tested?
After cloning the repo, cd into the repo cd quickcredit, install dependency by running npm install

- Testing with Mocha: ```run npm test```
- Testing with Postman: test every endpoint with this header: ```key: Content-Type value: application/json```
**Login with seeded admin credentials:** ```{ "email": "admin@quickcredit.com", "password": "admin password in .env file created" }``` **POST** request to ```localhost:7000/api/v1/users/auth/login```
**Admin views all current loans by making GET request to:**
```localhost:7000/api/v1/loans?status=approved&repaid=false```
**Admin views all repaid loans by making GET request to:**
```localhost:7000/api/v1/loans?status=approved&repaid=true```
Ensure authentication and authorization are provided, add **token** to **header**. Get the token from login endpoint: **SET** ```Bearer <token>```

#### Any background context you want to provide?
**SET** Admin password in ```.env``` by setting: ```ADMIN_PASS=admin_password```

#### What are the relevant pivotal tracker stories?
#165626029 #165626241

#### Screenshots (if appropriate)
Nil

#### Questions:
Nil