### PR TITLE
#166053449 Update admin approve and reject loan functionality

### DIFF
--- a/server/api/v1/db/loans.js
+++ b/server/api/v1/db/loans.js
@@ -59,6 +59,21 @@ const loans = [
     purpose: 'Travel',
     createdOn: new Date(),
   },
+  {
+    loanId: 856598562,
+    firstName: 'taiwo',
+    lastName: 'charles',
+    user: 'taewole@gmail.com',
+    tenor: 3,
+    amount: 90000,
+    status: 'pending',
+    repaid: false,
+    balance: 94500,
+    interest: 4500,
+    paymentInstallment: 31500.00,
+    purpose: 'Flexing',
+    createdOn: new Date(),
+  },
 ];
 
 export default loans;

--- a/server/api/v1/helpers/loanStatus.js
+++ b/server/api/v1/helpers/loanStatus.js
@@ -1,0 +1,13 @@
+const checkStatus = (status) => {
+  let validationMessage = '';
+  if (!status) {
+    validationMessage += 'Status is required';
+  } else if (status.trim() !== 'approved' && status !== 'rejected') {
+    validationMessage += 'Status can only be either \'approved\', or \'rejected\'';
+  }
+  return validationMessage;
+};
+
+export default {
+  checkStatus,
+};

--- a/server/api/v1/middleware/loanValidator.js
+++ b/server/api/v1/middleware/loanValidator.js
@@ -9,18 +9,6 @@ class LoanValidator {
       : res.status(400).json({ status: 400, error: validationMessage });
   }
 
-  static validateLoanStatus(req, res, next) {
-    let validationMessage = '';
-    const status = req.body.status.trim();
-    if (!status) {
-      validationMessage += 'Status is required';
-    } else if (status.trim() !== 'approved' && status !== 'rejected' && status !== 'pending') {
-      validationMessage += 'Status can only be either \'approved\', \'rejected\' or \'pending\'';
-    }
-    return (validationMessage.length === 0) ? next()
-      : res.status(400).json({ status: 400, error: validationMessage });
-  }
-
   static validateLoanId(req, res, next) {
     let validationMessage = '';
     let { loanId } = req.params;

--- a/server/api/v1/middleware/userValidator.js
+++ b/server/api/v1/middleware/userValidator.js
@@ -60,18 +60,6 @@ class UserValidator {
     return (validationMessage.length === 0) ? next()
       : res.status(400).json({ status: 400, error: validationMessage });
   }
-
-  static validateVerificationStatus(req, res, next) {
-    let validationMessage = '';
-    const status = req.body.status.trim();
-    if (!status) {
-      validationMessage += 'Status is required';
-    } else if (status.trim() !== 'verified' && status !== 'unverified') {
-      validationMessage += 'Status can only be either \'verified\', or \'unverified\'';
-    }
-    return (validationMessage.length === 0) ? next()
-      : res.status(400).json({ status: 400, error: validationMessage });
-  }
 }
 
 export default UserValidator;

--- a/server/api/v1/routes/loanRoute.js
+++ b/server/api/v1/routes/loanRoute.js
@@ -3,12 +3,12 @@ import express from 'express';
 import loanController from '../controllers/loanController';
 import jwt from '../middleware/jwt';
 import loanValidator from '../middleware/loanValidator';
-
+import checker from '../middleware/checker';
 
 const loanRouter = express.Router();
 
 loanRouter.post('/', jwt.validateToken, loanController.applyForLoan);
-loanRouter.patch('/:loanId', jwt.validateToken, loanValidator.validateLoanStatus, loanController.adminApproveRejectLoan);
+loanRouter.patch('/:loanId', jwt.validateToken, checker.checkAdminStatus, loanValidator.validateLoanId, loanController.adminApproveRejectLoan);
 loanRouter.post('/:loanId/repayment', jwt.validateToken, loanValidator.validateLoanRepayment, loanController.loanRepayment);
 loanRouter.get('/:loanId/repayment', jwt.validateToken, loanValidator.validateLoanId, loanController.getRepayment);
 loanRouter.get('/', jwt.validateToken, loanController.getAllLoan);


### PR DESCRIPTION
#### What does this PR do?
Updates admin approve and reject loan functionality

#### Description of Task to be completed?
Have this endpoint working:
```POST: localhost:7000/api/v1/loans/:loanId```

#### How should this be manually tested?
After cloning the repo, cd into the repo ```cd quickcredit```, install dependency by running ```npm install```

- Testing with Mocha: run npm test
- Testing with Postman: test every endpoint with this ```header: key: Content-Type value: application/json```
**Add a user:** ```{ "email": "user email", "firstName": "user first name", "lastName": "user last name", "address": "user address","password": "password"}``` POST request to ```localhost:7000/api/v1/auth/signup```
**Login with seeded admin credentials:** ```{ "email": "admin@quickcredit.com", "password": "admin password in .env file created" }``` POST request to ```localhost:7000/api/v1/auth/login```
**Admin verifies user account by making PATCH request:**
To test authentication and authorization, add **token** to **header**. Get the token from login endpoint: **SET** ```Bearer <token>``` send ```{ "status": "verified" }``` PATCH request to ```localhost:7000/api/v1/users/:userEmail/verify```
**Create a loan by making a POST request to** ```localhost:7000/api/v1/loans```
**Admin can the verify laon application** by making a **PATCH** request to: ```localhost:7000/api/v1/loans/loanId```

#### Any background context you want to provide?
Users must be verified by an admin before they can apply for a loan
**SET** Admin password in ```.env``` by setting: ```ADMIN_PASS=admin_password```
User must have created a loan for Admin to approve or reject

#### What are the relevant pivotal tracker stories?
#166053449 

#### Screenshots (if appropriate)
Nil

#### Questions:
Nil