### PR TITLE
#166056931 Refactor getAllLoan method in LoanController

### DIFF
--- a/server/api/v1/controllers/loanController.js
+++ b/server/api/v1/controllers/loanController.js
@@ -188,37 +188,31 @@ class LoanController {
   }
 
   static getAllLoan(req, res) {
-    if (req.authData.isAdmin) {
-      const { status } = req.query;
-      const { repaid } = req.query;
-      if (typeof status !== 'undefined' && typeof repaid !== 'undefined') {
-        if (status !== 'approved') {
-          return res.status(400).json({ status: 400, error: 'status can only have the value: \'approved\'' });
-        }
-        if (repaid.toString() !== 'true' && repaid.toString() !== 'false') {
-          return res.status(400).json({ status: 400, error: 'repaid can only have the value: \'true\' or \'false\'' });
-        }
-        const currentLoans = loans.filter(existingLoan => ((existingLoan.status === status)
+    const { status } = req.query;
+    const { repaid } = req.query;
+    if (typeof status !== 'undefined' && typeof repaid !== 'undefined') {
+      if (status !== 'approved') {
+        return res.status(400).json({ status: 400, error: 'status can only have the value: \'approved\'' });
+      }
+      if (repaid.toString() !== 'true' && repaid.toString() !== 'false') {
+        return res.status(400).json({ status: 400, error: 'repaid can only have the value: \'true\' or \'false\'' });
+      }
+      const currentLoans = loans.filter(existingLoan => ((existingLoan.status === status)
         && ((existingLoan.repaid).toString() === repaid.toString())));
-        return res.status(200).json({
-          status: 200,
-          data: currentLoans,
-        });
-      }
-      if (loans.length === 0) {
-        return res.status(200).json({
-          status: 404,
-          data: loans,
-        });
-      }
       return res.status(200).json({
         status: 200,
+        data: currentLoans,
+      });
+    }
+    if (loans.length === 0) {
+      return res.status(200).json({
+        status: 404,
         data: loans,
       });
     }
-    return res.status(403).json({
-      status: 403,
-      error: 'You\'re forbidden to perform this action.',
+    return res.status(200).json({
+      status: 200,
+      data: loans,
     });
   }
 

--- a/server/api/v1/routes/loanRoute.js
+++ b/server/api/v1/routes/loanRoute.js
@@ -11,7 +11,7 @@ loanRouter.post('/', jwt.validateToken, loanController.applyForLoan);
 loanRouter.patch('/:loanId', jwt.validateToken, checker.checkAdminStatus, loanValidator.validateLoanId, loanController.adminApproveRejectLoan);
 loanRouter.post('/:loanId/repayment', jwt.validateToken, loanValidator.validateLoanRepayment, loanController.loanRepayment);
 loanRouter.get('/:loanId/repayment', jwt.validateToken, loanValidator.validateLoanId, loanController.getRepayment);
-loanRouter.get('/', jwt.validateToken, loanController.getAllLoan);
+loanRouter.get('/', jwt.validateToken, checker.checkAdminStatus, loanController.getAllLoan);
 loanRouter.get('/:loanId', jwt.validateToken, loanValidator.validateLoanId, loanController.getALoan);
 
 export default loanRouter;


### PR DESCRIPTION
#### What does this PR do?
Add middleware to the getAllLoan routes to only approve admin to access the getAllLoan  method in the LoanController class

#### Description of Task to be completed?
Have these endpoints working:
```GET: localhost:7000/api/v1/loans/```
```GET: localhost:7000/api/v1/loans/?status=approved&&repaid=false```
```GET: localhost:7000/api/v1/loans/?status=approved&&repaid=true```

#### How should this be manually tested?
After cloning the repo, cd into the repo ```cd quickcredit```, install dependency by running ```npm install```

- Testing with Mocha: run npm test
- Testing with Postman: test every endpoint with this ```header: key: Content-Type value: application/json```
**Login with seeded admin credentials:** ```{ "email": "admin@quickcredit.com", "password": "admin password in .env file created" }``` POST request to ```localhost:7000/api/v1/auth/login```
To test authentication and authorization, add **token** to **header**. Get the token from login endpoint: **SET** ```Bearer <token>``` 
- **GET ALL LOANS** by making a ```GET``` request to: ```localhost:7000/api/v1/loans```
- **GET REPAID LOANS** by making a ```GET``` request to: ```localhost:7000/api/v1/loans/?status=approved&&repaid=true```
- **GET CURRENT LOANS** by making a ```GET``` request to: ```localhost:7000/api/v1/loans/?status=approved&&repaid=false```

#### Any background context you want to provide?
Users must be verified by an admin before they can apply for a loan
**SET** Admin password in ```.env``` by setting: ```ADMIN_PASS=admin_password```
User must have created a loan for Admin to approve or reject

#### What are the relevant pivotal tracker stories?
#166056931 

#### Screenshots (if appropriate)
Nil

#### Questions:
Nil